### PR TITLE
Feature/add status to log

### DIFF
--- a/Sources/DataDogLog/DataDogLogHandler.swift
+++ b/Sources/DataDogLog/DataDogLogHandler.swift
@@ -24,7 +24,7 @@ public struct DataDogLogHandler: LogHandler {
         let logMetadata = metadata.map { $0.merging(callsite) { $1 } } ?? callsite
         let mergedMetadata = self.metadata.merging(logMetadata) { $1 }
         let ddMessage = Message(level: level, message: "\(message)")
-        let log = Log(ddsource: label, ddtags: "\(mergedMetadata.prettified.map { "\($0)" } ?? "")", hostname: self.hostname ?? "", message: "\(ddMessage)")
+        let log = Log(ddsource: label, ddtags: "\(mergedMetadata.prettified.map { "\($0)" } ?? "")", hostname: self.hostname ?? "", message: "\(ddMessage)", status: "\(level)")
 
         session.send(log, key: key) { result in
             if case .failure(let message) = result {

--- a/Sources/DataDogLog/Log.swift
+++ b/Sources/DataDogLog/Log.swift
@@ -1,11 +1,18 @@
 import Logging
 
-/// https://docs.datadoghq.com/logs/log_collection/?tab=http#reserved-attributes
+/// Attribute for Datadog Logs
+///
+/// See https://docs.datadoghq.com/logs/log_collection/#reserved-attributes
 struct Log: Encodable {
     let ddsource: String
     let ddtags: String
     let hostname: String
     let message: String
+    
+    /// Log Status
+    ///
+    /// Logger.Level.trace will be sorted into Datadog as .debug.
+    /// See https://docs.datadoghq.com/logs/processing/processors/#log-status-remapper for details.
     let status: String
 }
 

--- a/Sources/DataDogLog/Log.swift
+++ b/Sources/DataDogLog/Log.swift
@@ -1,10 +1,12 @@
 import Logging
 
+/// https://docs.datadoghq.com/logs/log_collection/?tab=http#reserved-attributes
 struct Log: Encodable {
     let ddsource: String
     let ddtags: String
     let hostname: String
     let message: String
+    let status: String
 }
 
 struct Message: CustomStringConvertible {


### PR DESCRIPTION
Hi jagreenwood.

I've been trying out your nice library. 
I wanted to add status to the attribute, so I did so. I've added a brief comment to the source.

Datadog was able to interpret most of the Log.Level definition in swift-log.
Level definitions in swift-log, but the trace has been bundled into a debug. I found that in the [Datadog Doc](https://docs.datadoghq.com/logs/processing/processors/#log-status-remapper).

So, I'm sorry for the simple PullRequest. Please check😁.
