### PR TITLE
Add support for EU region

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,11 @@ This call will send the following payload to Datadog:
     "ddtags": "callsite:testLog():39,foo:bar,request-id:abc-123"
 }
 ```
+
+### Select Region
+
+The Datadog API uses a different URL in the EU region compared to the US. If your account was created using Datadog EU, you need to set the `region` option when initializing `DataDogLogHandler`:
+
+```swift
+DataDogLogHandler(label: $0, key: "xxx", hostname: "hostname", region: .EU)
+```

--- a/Sources/DataDogLog/DataDogLogHandler.swift
+++ b/Sources/DataDogLog/DataDogLogHandler.swift
@@ -10,13 +10,16 @@ public struct DataDogLogHandler: LogHandler {
     public var label: String
     public var hostname: String?
     internal let key: String
+    // Region for URL
+    internal let region: Region
 
     var session: Session = URLSession.shared
 
-    public init(label: String, key: String, hostname: String? = nil) {
+    public init(label: String, key: String, hostname: String? = nil, region: Region = .US) {
         self.label = label
         self.key = key
         self.hostname = hostname
+        self.region = region
     }
 
     public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {
@@ -26,7 +29,7 @@ public struct DataDogLogHandler: LogHandler {
         let ddMessage = Message(level: level, message: "\(message)")
         let log = Log(ddsource: label, ddtags: "\(mergedMetadata.prettified.map { "\($0)" } ?? "")", hostname: self.hostname ?? "", message: "\(ddMessage)")
 
-        session.send(log, key: key) { result in
+        session.send(log, key: key, region: region) { result in
             if case .failure(let message) = result {
                 debugPrint(message)
             }

--- a/Sources/DataDogLog/DataDogSession.swift
+++ b/Sources/DataDogLog/DataDogSession.swift
@@ -7,20 +7,18 @@ import Logging
 typealias StatusCode = Int
 
 protocol Session {
-    func send(_ log: Log, key: String, handler: @escaping (Result<StatusCode, Error>) -> ())
+    func send(_ log: Log, key: String, region: Region, handler: @escaping (Result<StatusCode, Error>) -> ())
 }
 
 extension String: Error {}
 extension Optional: Error where Wrapped == String {}
 
 extension URLSession: Session {
-    static let url = URL(string: "https://http-intake.logs.datadoghq.com/v1/input")!
-
-    func send(_ log: Log, key: String, handler: @escaping (Result<StatusCode, Error>) -> ()) {
+    func send(_ log: Log, key: String, region: Region, handler: @escaping (Result<StatusCode, Error>) -> ()) {
         do {
             let data = try JSONEncoder().encode(log)
 
-            var request = URLRequest(url: URLSession.url)
+            var request = URLRequest(url: region.getURL())
             request.httpMethod = "POST"
             request.httpBody = data
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Sources/DataDogLog/Region.swift
+++ b/Sources/DataDogLog/Region.swift
@@ -1,0 +1,23 @@
+//
+//  File.swift
+//  
+//
+//  Created by Hannes Hertach on 15.09.20.
+//
+
+import Foundation
+
+public enum Region {
+    case EU, US
+}
+
+extension Region {
+    func getURL() -> URL {
+        switch (self) {
+        case .EU:
+            return URL(string: "https://http-intake.logs.datadoghq.eu/v1/input")!
+        case .US:
+            return URL(string: "https://http-intake.logs.datadoghq.com/v1/input")!
+        }
+    }
+}

--- a/Sources/DataDogLog/Region.swift
+++ b/Sources/DataDogLog/Region.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by Hannes Hertach on 15.09.20.
-//
-
 import Foundation
 
 public enum Region {

--- a/Tests/DataDogLogTests/DataDogLogTests.swift
+++ b/Tests/DataDogLogTests/DataDogLogTests.swift
@@ -7,7 +7,7 @@ class TestSession: Session {
     var hostname: String?
     var message: String?
 
-    func send(_ log: Log, key: String, handler: @escaping (Result<StatusCode, Error>) -> ()) {
+    func send(_ log: Log, key: String, region: Region, handler: @escaping (Result<StatusCode, Error>) -> ()) {
         source = log.ddsource
         tags = log.ddtags
         hostname = log.hostname
@@ -36,6 +36,18 @@ final class DataDogLogTests: XCTestCase {
         XCTAssertEqual(expectedSource, session.source, "Expected \(expectedSource), result was \(String(describing: session.source))")
         XCTAssertEqual(expectedHostname, session.hostname, "Expected \(expectedHostname), result was \(String(describing: session.hostname))")
         XCTAssertEqual(expectedTags, session.tags, "Expected \(expectedTags), result was \(String(describing: session.tags))")
+    }
+    
+    func testRegionURL() {
+        let euLogHandler = DataDogLogHandler(label: "test", key: "test", region: .EU)
+        let usLogHandler = DataDogLogHandler(label: "test", key: "test", region: .US)
+        let defaultLogHandler = DataDogLogHandler(label: "test", key: "test")
+        
+        XCTAssert(euLogHandler.region == .EU)
+        XCTAssert(euLogHandler.region.getURL().absoluteString == "https://http-intake.logs.datadoghq.eu/v1/input")
+        XCTAssert(usLogHandler.region == .US)
+        XCTAssert(usLogHandler.region.getURL().absoluteString == "https://http-intake.logs.datadoghq.com/v1/input")
+        XCTAssert(defaultLogHandler.region == .US)
     }
 
     static var allTests = [


### PR DESCRIPTION
Thanks for your library.

We use Datadog on the "EU" region. The API URL for this Region is different from the US region. This PR adds an option to switch between regions.

I closed the last PR so I can continue pushing to master on my fork without updating this PR.