### PR TITLE
Add Service to Log

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To send logs to Datadog, initialize a `Logger` instance and send a message with 
 import DataDogLog
 
 let logger = Logger(label: "com.swift-log.awesome-app")
-logger.error("unfortunate error", metadata: ["request-id": "abc-123"])
+logger.error("unfortunate error", metadata: ["request-id": "abc-123"], source: "module-name")
 ```
 
 This call will send the following payload to Datadog:
@@ -56,9 +56,10 @@ This call will send the following payload to Datadog:
 {
     "message": "2020-05-27T06:37:17-0400 ERROR: unfortunate error",
     "hostname": "hostname",
-    "ddsource": "com.swift-log.awesome-app",
+    "ddsource": "module-name",
     "ddtags": "callsite:testLog():39,foo:bar,request-id:abc-123",
     "status": "error"
+    "service": "com.swift-log.awesome-app"
 }
 ```
 

--- a/Sources/DataDogLog/DataDogLogHandler.swift
+++ b/Sources/DataDogLog/DataDogLogHandler.swift
@@ -15,19 +15,36 @@ public struct DataDogLogHandler: LogHandler {
 
     var session: Session = URLSession.shared
 
-    public init(label: String, key: String, hostname: String? = nil, region: Region = .US) {
+    public init(
+        label: String,
+        key: String,
+        hostname: String? = nil,
+        region: Region = .US) {
         self.label = label
         self.key = key
         self.hostname = hostname
         self.region = region
     }
 
-    public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {
+    public func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt) {
         let callsite: [String: Logger.MetadataValue] = ["callsite": "\(function):\(line)"]
         let logMetadata = metadata.map { $0.merging(callsite) { $1 } } ?? callsite
         let mergedMetadata = self.metadata.merging(logMetadata) { $1 }
         let ddMessage = Message(level: level, message: "\(message)")
-        let log = Log(ddsource: label, ddtags: "\(mergedMetadata.prettified.map { "\($0)" } ?? "")", hostname: self.hostname ?? "", message: "\(ddMessage)", status: "\(level)")
+        let log = Log(
+            ddsource: source,
+            ddtags: "\(mergedMetadata.prettified.map { "\($0)" } ?? "")",
+            hostname: self.hostname ?? "",
+            message: "\(ddMessage)",
+            service: label,
+            status: "\(level)")
 
         session.send(log, key: key, region: region) { result in
             if case .failure(let message) = result {

--- a/Sources/DataDogLog/Log.swift
+++ b/Sources/DataDogLog/Log.swift
@@ -2,12 +2,13 @@ import Logging
 
 /// Attribute for Datadog Logs
 ///
-/// See https://docs.datadoghq.com/logs/log_collection/#reserved-attributes
+/// See https://docs.datadoghq.com/api/latest/logs/#send-logs-v1
 struct Log: Encodable {
     let ddsource: String
     let ddtags: String
     let hostname: String
     let message: String
+    let service: String
     
     /// Log Status
     ///

--- a/Tests/DataDogLogTests/DataDogLogTests.swift
+++ b/Tests/DataDogLogTests/DataDogLogTests.swift
@@ -6,26 +6,29 @@ class TestSession: Session {
     var tags: String?
     var hostname: String?
     var message: String?
+    var service: String?
 
     func send(_ log: Log, key: String, region: Region, handler: @escaping (Result<StatusCode, Error>) -> ()) {
         source = log.ddsource
         tags = log.ddtags
         hostname = log.hostname
         message = log.message
+        service = log.service
     }
 }
 
 final class DataDogLogTests: XCTestCase {
     func testLog() {
         let expectedMessage = "Testing swift-log-data-dog"
-        let expectedSource = "com.swift-log"
+        let expectedSource = "swift-log"
         let expectedHostname = "xctest"
         let expectedTags = "callsite:test-function:100,foo:bar,log:swift"
+        let expectedService = "com.swift-log"
 
-        var handler = DataDogLogHandler(label: expectedSource, key: "", hostname: expectedHostname)
+        var handler = DataDogLogHandler(label: expectedService, key: "", hostname: expectedHostname)
         handler.metadata = ["foo":"bar"]
         handler.session = TestSession()
-        handler.log(level: .error, message: "\(expectedMessage)", metadata: ["log":"swift"], file: "test-file", function: "test-function", line: 100)
+        handler.log(level: .error, message: "\(expectedMessage)", metadata: ["log":"swift"], source: expectedSource, file: "test-file", function: "test-function", line: 100)
 
         guard let session = handler.session as? TestSession else {
             XCTAssert(false, "Invalid Test")
@@ -36,6 +39,7 @@ final class DataDogLogTests: XCTestCase {
         XCTAssertEqual(expectedSource, session.source, "Expected \(expectedSource), result was \(String(describing: session.source))")
         XCTAssertEqual(expectedHostname, session.hostname, "Expected \(expectedHostname), result was \(String(describing: session.hostname))")
         XCTAssertEqual(expectedTags, session.tags, "Expected \(expectedTags), result was \(String(describing: session.tags))")
+        XCTAssertEqual(expectedService, session.service, "Expected \(expectedService), result was \(String(describing: session.service))")
     }
     
     func testRegionURL() {


### PR DESCRIPTION
Adds `service` to log instance and now properly handles passing in `source` when a log is sent.
