### PR TITLE
replace deprecated v1 API endpoints w/ v2, add new regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This call will send the following payload to Datadog:
 
 ### Select Region 🌎
 
-The Datadog API uses a different URL in the EU region compared to the US. If your account was created using Datadog EU, you need to set the `region` option when initializing `DataDogLogHandler`:
+The Datadog API runs on multiple regions (e.g. US, EU, US3, US5, US1FED), with different API endpoints. If your account was not created in the default **US** region, you need to set the `region` option when initializing `DataDogLogHandler`:
 
 ```swift
 DataDogLogHandler(label: $0, key: "xxx", hostname: "hostname", region: .EU)

--- a/Sources/DataDogLog/Region.swift
+++ b/Sources/DataDogLog/Region.swift
@@ -1,16 +1,22 @@
 import Foundation
 
 public enum Region {
-    case EU, US
+    case EU, US, US3, US5, US1FED
 }
 
 extension Region {
     func getURL() -> URL {
         switch (self) {
         case .EU:
-            return URL(string: "https://http-intake.logs.datadoghq.eu/v1/input")!
+            return URL(string: "https://http-intake.logs.datadoghq.eu/api/v2/logs")!
         case .US:
-            return URL(string: "https://http-intake.logs.datadoghq.com/v1/input")!
+            return URL(string: "https://http-intake.logs.datadoghq.com/api/v2/logs")!
+        case .US3:
+            return URL(string: "https://http-intake.logs.us3.datadoghq.com/api/v2/logs")!
+        case .US5:
+            return URL(string: "https://http-intake.logs.us5.datadoghq.com/api/v2/logs")!
+        case .US1FED:
+            return URL(string: "https://http-intake.logs.ddog-gov.com/api/v2/logs")!
         }
     }
 }

--- a/Tests/DataDogLogTests/DataDogLogTests.swift
+++ b/Tests/DataDogLogTests/DataDogLogTests.swift
@@ -48,9 +48,9 @@ final class DataDogLogTests: XCTestCase {
         let defaultLogHandler = DataDogLogHandler(label: "test", key: "test")
         
         XCTAssert(euLogHandler.region == .EU)
-        XCTAssert(euLogHandler.region.getURL().absoluteString == "https://http-intake.logs.datadoghq.eu/v1/input")
+        XCTAssert(euLogHandler.region.getURL().absoluteString == "https://http-intake.logs.datadoghq.eu/api/v2/logs")
         XCTAssert(usLogHandler.region == .US)
-        XCTAssert(usLogHandler.region.getURL().absoluteString == "https://http-intake.logs.datadoghq.com/v1/input")
+        XCTAssert(usLogHandler.region.getURL().absoluteString == "https://http-intake.logs.datadoghq.com/api/v2/logs")
         XCTAssert(defaultLogHandler.region == .US)
     }
 


### PR DESCRIPTION
See https://docs.datadoghq.com/api/latest/logs/#send-logs

The only differences between v1 and v2 are the HTTP response status codes. Since the API response validation in DataDogSession accepts anything in the 200-300 range, the current implementation works fine.

I have tested this only w/ the EU endpoint. The v1 endpoint did not event work for me.