### PR TITLE
Bugfix: Shutdown Crash

### DIFF
--- a/Sources/DataDogLog/Internal/NetworkClient.swift
+++ b/Sources/DataDogLog/Internal/NetworkClient.swift
@@ -24,7 +24,7 @@ final class NetworkClient: Sendable {
 
     deinit {
 #if os(Linux)
-        try? client.syncShutdown()
+        client.shutdown()
 #endif
     }
 


### PR DESCRIPTION
Calls the safer `shutdown()` in AsyncHTTPClient method to prevent potential deadlocks.